### PR TITLE
archive reading in __load_data in TarFileDataLoader fixed

### DIFF
--- a/local/tf/examples_io.py
+++ b/local/tf/examples_io.py
@@ -7,6 +7,7 @@ import time
 import queue
 from threading import Thread
 from kaldi_io import read_mat
+from io import BytesIO
 
 
 def process_range_file(range_file_path, minibatch_count, minibatch_size, logger=None):
@@ -243,7 +244,11 @@ class TarFileDataLoader(object):
             idx = int(name[:-4].split('_')[1])
             label = self._train_labels[idx]
             start_time = time.time()
-            mat = np.load(self._tar.extractfile(name))
+            array_file = BytesIO()
+            array_file.write(self._tar.extractfile(name).read())
+            array_file.seek(0)
+            mat = np.load(array_file)
+
             if self._logger is not None:
                 self._logger.info("Loading one minibatch take %d seconds." % (time.time() - start_time))
             self.queue.put((mat, label))


### PR DESCRIPTION
numpy.load() in mat = np.load(self._tar.extractfile(name) was throwing an error "cannot read from tar archive in python3 ('_FileInFile' object has no attribute 'fileno')".